### PR TITLE
Move neovide

### DIFF
--- a/bundles/workstation_nixos.nix
+++ b/bundles/workstation_nixos.nix
@@ -41,6 +41,7 @@
 
   environment.systemPackages = with pkgs; [
     vim             # Good for backup 
+    neovide         # Needs to be here because neovide doesn't work on M1
     wget
     git
     zsh

--- a/profiles/modules/neovim/default.nix
+++ b/profiles/modules/neovim/default.nix
@@ -4,7 +4,6 @@
     rnix-lsp
     fd
     nodePackages.coc-pyright
-    neovide
     (
       neovim.override {
         configure = ( import ./customization.nix { pkgs = pkgs; config = config; } );


### PR DESCRIPTION
Neovide was moved to the workstation nixos bundle because it doesn't build on the MacOS M1. It therefore cannot belong to any use of the neovim module and needs to only belong to nixos installs.