### PR TITLE
Removed NerdTree syntax highlight

### DIFF
--- a/profiles/modules/neovim/customization.nix
+++ b/profiles/modules/neovim/customization.nix
@@ -18,7 +18,6 @@ in
       (nvim-treesitter.withPlugins (_: pkgs.tree-sitter.allGrammars))
       nerdtree
       vim-devicons
-      vim-nerdtree-syntax-highlight
       vim-nix 
       vim-startify
       neoscroll-nvim


### PR DESCRIPTION
This was causing errors when starting NerdTree and when it was removed, nerd tree started to highlight (more) correctly.