### PR TITLE
Move nvim default editor to nixos

### DIFF
--- a/bundles/workstation_nixos.nix
+++ b/bundles/workstation_nixos.nix
@@ -1,5 +1,3 @@
-# Configs common to all workstation installations of Nixos
-
 { config, pkgs, ... }:
 
 {
@@ -57,6 +55,11 @@
     wine-staging
     winetricks
   ];
+
+  programs.neovim = {
+    enable = true;
+    defaultEditor = true;
+  };
 
   programs.steam = {
     enable = true;

--- a/profiles/modules/neovim/default.nix
+++ b/profiles/modules/neovim/default.nix
@@ -1,11 +1,5 @@
 { pkgs, config, home-manager, username, ... }:
 {
-
-  programs.neovim = {
-    enable = true;
-    defaultEditor = true;
-  };
-
   environment.systemPackages = with pkgs; [
     rnix-lsp
     fd


### PR DESCRIPTION
Darwin is not able to set a default editor because MacOS isn't as elegant as Linux.