### PR TITLE
Removed Python 10

### DIFF
--- a/bundles/common.nix
+++ b/bundles/common.nix
@@ -7,9 +7,6 @@
     python39Full
     python39Packages.isort
     python39Packages.black
-    python310
-    python310Packages.black
-    python310Packages.isort
     poetry
     nodejs
     yarn


### PR DESCRIPTION
It appears that Darwin is unable to handle multiple python versions without some extra special tweaking.