### PR TITLE
Add outter context to environment.stystem packages

### DIFF
--- a/bundles/common.nix
+++ b/bundles/common.nix
@@ -10,7 +10,7 @@
     };
   };
 
-  environment.systemPackages = with pkgs; [
+  config.environment.systemPackages = with pkgs; [
 
     # Programing tools
     # ----------------


### PR DESCRIPTION
This doesn't build unless the outer context is included.