### PR TITLE
Something odd is happening here

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,7 +25,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1673979760,
-        "narHash": "sha256-LWQe2AZX/kfK7uC2YoqSSTz02l9XrbfDjv9b6/wxGBc=",
+        "narHash": "sha256-3mME+2iCph/MHl7PzY7W6H6/Npg0n0IFRijMEOF44L0=",
         "owner": "Fausto-Korpsvart",
         "repo": "Gruvbox-GTK-Theme",
         "rev": "13fe1d7bfb43557642a37da3498cd35ba285c593",


### PR DESCRIPTION
The SHA generated by nixos appears to be different than the hash generated by nix darwin in this flake. This could be a side effect of the system version change (from unstable to stable). For now, I have more faith in the "correctness" of nixos's SHA and will deal with nix darwin later.