### PR TITLE
Changed alacritty font

### DIFF
--- a/homes/modules/terminal/alacritty.yml
+++ b/homes/modules/terminal/alacritty.yml
@@ -12,7 +12,7 @@ font:
     x: 0
     y: 2
   normal:
-    family: "Iosevka Nerd Font"
+    family: "Lilex Nerd Font"
 
 env:
   TERM: xterm-256color

--- a/homes/modules/terminal/default.nix
+++ b/homes/modules/terminal/default.nix
@@ -79,7 +79,7 @@ in
 
   fonts = {
     fonts = with pkgs; [
-      (nerdfonts.override { fonts = [ "Iosevka" ]; })
+      (nerdfonts.override { fonts = [ "Lilex" ]; })
       font-awesome
     ];
   };


### PR DESCRIPTION
Alacritty font was changed because Iosevka stopped working on MacOS after update to NixOS 23.05. Icons stopped rendering and font had artifacts.