### PR TITLE
Removes x11 mesa drivers from nvidia config

### DIFF
--- a/hosts/common/nvidia-standard.nix
+++ b/hosts/common/nvidia-standard.nix
@@ -10,12 +10,6 @@
       package = config.boot.kernelPackages.nvidiaPackages.stable;
       modesetting.enable = true;
     };
-    opengl = {
-      enable = true;
-      extraPackages = [
-        pkgs.mesa.drivers
-        pkgs.linuxPackages.nvidia_x11.out
-      ];
-    };
+    opengl.enable = true;
   };
 }


### PR DESCRIPTION
These settings caused issues with electron apps